### PR TITLE
Move typings to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
     "tslint": "^3.11.0",
     "tslint-config-standard": "^1.2.2",
     "typescript": "^2.0.0",
-    "webpack": "beta"
-  },
-  "dependencies": {
-    "@easy-webpack/assign": "^0.9.9 || ^1.0.0",
+    "webpack": "beta",
     "@types/debug": "^0.0.29",
     "@types/lodash": "^4.14.37",
     "@types/node": "^6.0.46",
     "@types/source-map": "^0.1.28",
     "@types/uglify-js": "^2.6.28",
-    "@types/webpack": "^1.12.35",
+    "@types/webpack": "^1.12.35"
+  },
+  "dependencies": {
+    "@easy-webpack/assign": "^0.9.9 || ^1.0.0",
     "lodash": "^4.13.1"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "typescript": "^2.0.0",
     "webpack": "beta",
     "@types/debug": "^0.0.29",
-    "@types/lodash": "^4.14.37",
     "@types/node": "^6.0.46",
     "@types/source-map": "^0.1.28",
     "@types/uglify-js": "^2.6.28",
     "@types/webpack": "^1.12.35"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.37",
     "@easy-webpack/assign": "^0.9.9 || ^1.0.0",
     "lodash": "^4.13.1"
   },


### PR DESCRIPTION
Leaving @types in dependencies causes them to be installed when @easy-webpack/core is installed, inferring with the application using easy-webpack. Typings are not required for using easy-webpack, only for development of easy-webpack. It's especially important in case of @types/nodes which overrides some methods such as setTimeout which causes compilation error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/151032607952727/207905365111985)
